### PR TITLE
More groups

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -22,6 +22,11 @@ splunkforwarder:
   # It's recommended to disable port 8089 in forwarder
   disable_management_port: True
 
+  # Extra groups the 'splunk' users should also be a member of
+  user_extra_groups:
+    - group1
+    - group2
+
   cert_filename: selfsignedcert.pem
   intermediate: True
   forward_servers:

--- a/splunkforwarder/user.sls
+++ b/splunkforwarder/user.sls
@@ -8,5 +8,8 @@ splunk_user:
     - home: /opt/splunkforwarder
     - groups:
       - splunk
+      {% for group in salt['pillar.get']('splunkforwarder:user_extra_groups', []).items()|sort -%}
+      - {{ group }}
+      {%- endfor %}
     - require:
       - group: splunk_group

--- a/splunkforwarder/user.sls
+++ b/splunkforwarder/user.sls
@@ -8,7 +8,7 @@ splunk_user:
     - home: /opt/splunkforwarder
     - groups:
       - splunk
-      {% for group in salt['pillar.get']('splunkforwarder:user_extra_groups', []).items()|sort -%}
+      {% for group in salt['pillar.get']('splunkforwarder:user_extra_groups', [])|sort -%}
       - {{ group }}
       {%- endfor %}
     - require:


### PR DESCRIPTION
This allows for you to add more groups that the 'splunk' user should be a member of. For example: 'ossec'